### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNSpeak.podspec
+++ b/RNSpeak.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/ericlewis/react-native-speak.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)